### PR TITLE
Remove Cosign keyless signing using Rekor

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @castrojo

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -108,7 +108,7 @@ jobs:
         env:
           TAGS: ${{ steps.push.outputs.digest }}
           COSIGN_PRIVATE_KEY: ${{secrets.SIGNING_SECRET}}
-          COSIGN_EXPERIMENTAL: true
+          COSIGN_EXPERIMENTAL: false
       - name: Echo outputs
         run: |
           echo "${{ toJSON(steps.push.outputs) }}"


### PR DESCRIPTION
Part of #17 

I'm not 100% sure if this will work, but it removes one possibility.  
When using `COSIGN_EXPERIMENTAL`, you are opting in to keyless signing.  As you wish to use the keys stored in GitHub, this is not an being used, so must be disabled.