### PR TITLE
Directly reference private key in signing step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,7 +58,7 @@ jobs:
       # Only needed when running `cosign sign` using a key
       - name: Write signing key to disk
         run: |
-          echo "$COSIGN_PRIVATE_KEY" > cosign.key
+          echo "${{ env.COSIGN_PRIVATE_KEY }}" > cosign.key
           # DEBUG: get character count of key
           wc -c cosign.key
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,9 +58,11 @@ jobs:
       # Only needed when running `cosign sign` using a key
       - name: Write signing key to disk
         run: |
-          echo "${{ secrets.SIGNING_SECRET }}" > cosign.key
+          echo "$COSIGN_PRIVATE_KEY" > cosign.key
           # DEBUG: get character count of key
           wc -c cosign.key
+        env:
+          COSIGN_PRIVATE_KEY: ${{ secrets.SIGNING_SECRET }}
 
       # Build image using Buildah action
       - name: Build Image

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,15 +55,6 @@ jobs:
           fi
           echo "alias_tags=${alias_tags[*]}" >> $GITHUB_OUTPUT
 
-      # Only needed when running `cosign sign` using a key
-      - name: Write signing key to disk
-        run: |
-          echo "${{ env.COSIGN_PRIVATE_KEY }}" > cosign.key
-          # DEBUG: get character count of key
-          wc -c cosign.key
-        env:
-          COSIGN_PRIVATE_KEY: ${{ secrets.SIGNING_SECRET }}
-
       # Build image using Buildah action
       - name: Build Image
         id: build_image
@@ -106,6 +97,15 @@ jobs:
 
       # Sign container
       - uses: sigstore/cosign-installer@main
+
+      # Only needed when running `cosign sign` using a key
+      - name: Write signing key to disk
+        run: |
+          echo "${{ env.COSIGN_PRIVATE_KEY }}" > cosign.key
+          # DEBUG: get character count of key
+          wc -c cosign.key
+        env:
+          COSIGN_PRIVATE_KEY: ${{ secrets.SIGNING_SECRET }}
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,6 +55,13 @@ jobs:
           fi
           echo "alias_tags=${alias_tags[*]}" >> $GITHUB_OUTPUT
 
+      # Only needed when running `cosign sign` using a key
+      - name: Write signing key to disk
+        run: |
+          echo "${{ secrets.COSIGN_PRIVATE_KEY }}" > cosign.key
+          # DEBUG: get character count of key
+          wc -c cosign.key
+
       # Build image using Buildah action
       - name: Build Image
         id: build_image
@@ -104,13 +111,6 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
-      # Only needed when running `cosign sign` using a key
-      - name: Write signing key to disk
-        run: |
-          echo "${{ secrets.COSIGN_PRIVATE_KEY }}" > cosign.key
-          # DEBUG: get character count of key
-          wc -c cosign.key
 
       - name: Sign container image
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,7 +62,7 @@ jobs:
           # DEBUG: get character count of key
           wc -c cosign.key
         env:
-          COSIGN_PRIVATE_KEY: ${{ secrets.SIGNING_SECRET }}
+          COSIGN_PRIVATE_KEY: test
 
       # Build image using Buildah action
       - name: Build Image

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,21 +94,31 @@ jobs:
           password: ${{ env.REGISTRY_PASSWORD }}
           extra-args: |
             --disable-content-trust
+
       # Sign container
       - uses: sigstore/cosign-installer@main
+
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Only needed when running `cosign sign` using a key
+      - name: Write signing key to disk
+        run: |
+          echo "${{ secrets.COSIGN_PRIVATE_KEY }}" > cosign.key
+          # DEBUG: get character count of key
+          wc -c cosign.key
+
       - name: Sign container image
         run: |
-          cosign sign ${{ steps.registry_case.outputs.lowercase }}/${{ env.IMAGE_NAME }}@${TAGS}
+          cosign sign --key cosign.key ${{ steps.registry_case.outputs.lowercase }}/${{ env.IMAGE_NAME }}@${TAGS}
         env:
           TAGS: ${{ steps.push.outputs.digest }}
-          COSIGN_PRIVATE_KEY: ${{secrets.SIGNING_SECRET}}
           COSIGN_EXPERIMENTAL: false
+
       - name: Echo outputs
         run: |
           echo "${{ toJSON(steps.push.outputs) }}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,7 +62,7 @@ jobs:
           # DEBUG: get character count of key
           wc -c cosign.key
         env:
-          COSIGN_PRIVATE_KEY: test
+          COSIGN_PRIVATE_KEY: ${{ secrets.SIGNING_SECRET }}
 
       # Build image using Buildah action
       - name: Build Image

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,7 +58,7 @@ jobs:
       # Only needed when running `cosign sign` using a key
       - name: Write signing key to disk
         run: |
-          echo "${{ secrets.COSIGN_PRIVATE_KEY }}" > cosign.key
+          echo "${{ secrets.SIGNING_SECRET }}" > cosign.key
           # DEBUG: get character count of key
           wc -c cosign.key
 


### PR DESCRIPTION

### WHEN MERGING THIS, PLEASE SQUASH
There are many useless commits that don't need to be in `main`