### PR TITLE
Add just task runner and example commands

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -8,7 +8,7 @@ COPY etc /etc
 COPY ublue-firstboot /usr/bin
 
 RUN rpm-ostree override remove firefox firefox-langpacks && \
-    rpm-ostree install distrobox gnome-tweaks && \
+    rpm-ostree install distrobox gnome-tweaks just && \
     sed -i 's/#AutomaticUpdatePolicy.*/AutomaticUpdatePolicy=stage/' /etc/rpm-ostreed.conf && \
     systemctl enable rpm-ostreed-automatic.timer && \
     systemctl enable flatpak-automatic.timer && \

--- a/README.md
+++ b/README.md
@@ -32,6 +32,26 @@ The `latest` tag will automatically point to the latest build.
 - Mozilla Firefox, Mozilla Thunderbird, Extension Manager, Libreoffice, DejaDup, FontDownloader, Flatseal, and the Celluloid Media Player
 - Core GNOME Applications installed from Flathub
   - GNOME Calculator, Calendar, Characters, Connections, Contacts, Evince, Firmware, Logs, Maps, NautilusPreviewer, TextEditor, Weather, baobab, clocks, eog, and font-viewer
+
+## Further Customization
+
+The `just` task runner is included for further customization after first boot.
+It will copy the template from `/etc/justfile` to your home directory.
+After that run the following commands:
+
+- `just` - Show all tasks, more will be added in the future
+- `just bios` - Reboot into the system bios (Useful for dualbooting)
+- Set up distroboxes for the following images:
+  - `just distrobox-boxkit`
+  - `just distrobox-debian`
+  - `just distrobox-opensuse`
+  - `just distrobox-ubuntu`
+- `just setup-flatpaks` - Install a selection of flatpaks, use this section to add your own apps
+- `just setup-gaming` - Install Steam, Heroic Game Launcher, OBS Studio, Discord, Boatswain, Bottles, and ProtonUp-Qt. MangoHud is installed and enabled by default, hit right Shift-F12 to toggle
+- `just update` - Update rpm-ostree, flatpaks, and distroboxes in one command
+
+Check the [just website](https://just.systems) for tips on modifying and adding your own recipes. 
+  
   
 ## Verification
 
@@ -39,4 +59,4 @@ These images are signed with sisgstore's [cosign](https://docs.sigstore.dev/cosi
 
     cosign verify --key cosign.pub ghcr.io/ublue-os/base
     
-If you're forking this repo you should [read the docs](https://docs.github.com/en/actions/security-guides/encrypted-secrets) on keeping secrets in github. You need to [generate a new keypair](https://docs.sigstore.dev/cosign/overview/) with cosign. The public key can be in your public repo (your users need it to check the signatures), and you can paste the private key in Settings -> Secrets -> Actions. 
+If you're forking this repo you should [read the docs](https://docs.github.com/en/actions/security-guides/encrypted-secrets) on keeping secrets in github. You need to [generate a new keypair](https://docs.sigstore.dev/cosign/overview/) with cosign. The public key can be in your public repo (your users need it to check the signatures), and you can paste the private key in Settings -> Secrets -> Actions.

--- a/etc/justfile
+++ b/etc/justfile
@@ -5,23 +5,23 @@ bios:
   systemctl reboot --firmware-setup
 
 distrobox-boxkit:
-  echo "Creating Boxkit distrobox ..."
+  echo 'Creating Boxkit distrobox ...'
   distrobox create --image ghcr.io/ublue-os/boxkit -n alpine 
 
 distrobox-debian:
-  echo "Creating Debian distrobox ..."
+  echo 'Creating Debian distrobox ...'
   distrobox create --image quay.io/toolbx-images/debian-toolbox:unstable -n debian
 
 distrobox-opensuse:
-  echo "Creating openSUSE distrobox ..."
+  echo 'Creating openSUSE distrobox ...'
   distrobox create --image quay.io/toolbx-images/opensuse-toolbox:tumbleweed -n opensuse
  
 distrobox-ubuntu:
-  echo "Creating Ubuntu distrobox ..."
+  echo 'Creating Ubuntu distrobox ...'
   distrobox create --image quay.io/toolbx-images/ubuntu-toolbox:22.04 -n ubuntu
   
 setup-flatpaks:
-  echo "Setting up your flatpaks..."
+  echo 'Setting up your flatpaks...'
   flatpak install -y --user \\
   com.discordapp.Discord \\
   com.mastermindzh.tidal-hifi \\
@@ -37,12 +37,12 @@ setup-flatpaks:
   us.zoom.Zoom  
   
 setup-pwa:
-  echo "Giving browser permission to create PWAs (Progressive Web Apps)"
+  echo 'Giving browser permission to create PWAs (Progressive Web Apps)'
   # Add for your favorite chromium-based browser
   flatpak override --user --filesystem=~/.local/share/applications --filesystem=~/.local/share/icons com.microsoft.Edge
 
 setup-gaming:
-  echo "Setting up gaming experience ... lock and load."
+  echo 'Setting up gaming experience ... lock and load.'
   flatpak install -y --user \\
   com.discordapp.Discord \\
   com.feaneron.Boatswain \\

--- a/etc/justfile
+++ b/etc/justfile
@@ -6,19 +6,19 @@ bios:
 
 distrobox-boxkit:
   echo 'Creating Boxkit distrobox ...'
-  distrobox create --image ghcr.io/ublue-os/boxkit -n alpine 
+  distrobox create --image ghcr.io/ublue-os/boxkit -n boxkit -Y
 
 distrobox-debian:
   echo 'Creating Debian distrobox ...'
-  distrobox create --image quay.io/toolbx-images/debian-toolbox:unstable -n debian
+  distrobox create --image quay.io/toolbx-images/debian-toolbox:unstable -n debian -Y
 
 distrobox-opensuse:
   echo 'Creating openSUSE distrobox ...'
-  distrobox create --image quay.io/toolbx-images/opensuse-toolbox:tumbleweed -n opensuse
+  distrobox create --image quay.io/toolbx-images/opensuse-toolbox:tumbleweed -n opensuse -Y
  
 distrobox-ubuntu:
   echo 'Creating Ubuntu distrobox ...'
-  distrobox create --image quay.io/toolbx-images/ubuntu-toolbox:22.04 -n ubuntu
+  distrobox create --image quay.io/toolbx-images/ubuntu-toolbox:22.04 -n ubuntu -Y
   
 setup-flatpaks:
   echo 'Setting up your flatpaks...'

--- a/etc/justfile
+++ b/etc/justfile
@@ -1,0 +1,67 @@
+default:
+  @just --list
+
+bios:
+  systemctl reboot --firmware-setup
+
+distrobox-boxkit:
+  echo "Creating Boxkit distrobox ..."
+  distrobox create --image ghcr.io/ublue-os/boxkit -n alpine 
+
+distrobox-debian:
+  echo "Creating Debian distrobox ..."
+  distrobox create --image quay.io/toolbx-images/debian-toolbox:unstable -n debian
+
+distrobox-opensuse:
+  echo "Creating openSUSE distrobox ..."
+  distrobox create --image quay.io/toolbx-images/opensuse-toolbox:tumbleweed -n opensuse
+ 
+distrobox-ubuntu:
+  echo "Creating Ubuntu distrobox ..."
+  distrobox create --image quay.io/toolbx-images/ubuntu-toolbox:22.04 -n ubuntu
+  
+setup-flatpaks:
+  echo "Setting up your flatpaks..."
+  flatpak install -y --user \\
+  com.discordapp.Discord \\
+  com.mastermindzh.tidal-hifi \\
+  com.microsoft.Edge \\
+  com.plexamp.Plexamp \\
+  com.slack.Slack \\
+  com.todoist.Todoist \\
+  com.visualstudio.code \\
+  im.riot.Riot \\
+  no.mifi.losslesscut \\
+  org.standardnotes.standardnotes \\
+  tv.plex.PlexDesktop \\
+  us.zoom.Zoom  
+  
+setup-pwa:
+  echo "Giving browser permission to create PWAs (Progressive Web Apps)"
+  # Add for your favorite chromium-based browser
+  flatpak override --user --filesystem=~/.local/share/applications --filesystem=~/.local/share/icons com.microsoft.Edge
+
+setup-gaming:
+  echo "Setting up gaming experience ... lock and load."
+  flatpak install -y --user \\
+  com.discordapp.Discord \\
+  com.feaneron.Boatswain \\
+  org.freedesktop.Platform.VulkanLayer.MangoHud//22.08 \\
+  org.freedesktop.Platform.VulkanLayer.OBSVkCapture//22.08 \\
+  org.freedesktop.Platform.VulkanLayer.vkBasalt//22.08 \\
+  com.heroicgameslauncher.hgl \\
+  com.obsproject.Studio \\
+  com.obsproject.Studio.Plugin.OBSVkCapture \\
+  com.obsproject.Studio.Plugin.Gstreamer \\
+  com.usebottles.bottles \\
+  com.valvesoftware.Steam \\
+  com.valvesoftware.Steam.Utility.gamescope \\
+  net.davidotek.pupgui2 \\
+  flatpak override com.usebottles.bottles --user --filesystem=xdg-data/applications 
+  flatpak override --user --env=MANGOHUD=1 com.valvesoftware.Steam 
+  flatpak override --user --env=MANGOHUD=1 com.heroicgameslauncher.hgl 
+ 
+update:
+  rpm-ostree update
+  flatpak update -y
+  distrobox upgrade -a

--- a/etc/justfile
+++ b/etc/justfile
@@ -56,7 +56,7 @@ setup-gaming:
   com.usebottles.bottles \\
   com.valvesoftware.Steam \\
   com.valvesoftware.Steam.Utility.gamescope \\
-  net.davidotek.pupgui2 \\
+  net.davidotek.pupgui2
   flatpak override com.usebottles.bottles --user --filesystem=xdg-data/applications 
   flatpak override --user --env=MANGOHUD=1 com.valvesoftware.Steam 
   flatpak override --user --env=MANGOHUD=1 com.heroicgameslauncher.hgl 

--- a/ublue-firstboot
+++ b/ublue-firstboot
@@ -130,6 +130,7 @@ echo "100"
 echo "# Reticulating Final Splines"
 mkdir -p "$HOME"/.config/ublue/
 touch "$HOME"/.config/ublue/firstboot-done
+cp -n /etc/justfile "$HOME"/.justfile
 
 ) | 
      


### PR DESCRIPTION
I'd like to make the default applications in firstboot smaller and make it easier to customize the apps after installation. Ideally we only install "core apps" in firstboot and leave the other apps up to whatever images are based off this one (Like LibreOffice, Tbird, etc). 

The intent here is to include a justfile with examples for post-setup tasks which are copied to the user's home on firstboot and then the user can use just post-installation. 