### PR TITLE
Add `just changelogs` alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ After that run the following commands:
 
 - `just` - Show all tasks, more will be added in the future
 - `just bios` - Reboot into the system bios (Useful for dualbooting)
+- `just changelogs` - Show the changelogs of the pending update
 - Set up distroboxes for the following images:
   - `just distrobox-boxkit`
   - `just distrobox-debian`

--- a/etc/justfile
+++ b/etc/justfile
@@ -4,6 +4,9 @@ default:
 bios:
   systemctl reboot --firmware-setup
 
+changelogs:
+  rpm-ostree db diff --changelogs
+
 distrobox-boxkit:
   echo 'Creating Boxkit distrobox ...'
   distrobox create --image ghcr.io/ublue-os/boxkit -n boxkit -Y


### PR DESCRIPTION
This is just `rpm-ostree db diff --changelogs` except easier to remember. 