### PR TITLE
Install the VanillaOS first-setup utility

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -8,8 +8,13 @@ COPY etc /etc
 COPY ublue-firstboot /usr/bin
 
 RUN rpm-ostree override remove firefox firefox-langpacks && \
-    rpm-ostree install distrobox gnome-tweaks just && \
+    rpm-ostree install distrobox gnome-tweaks just vte291-gtk4-devel.x86_64 && \
     sed -i 's/#AutomaticUpdatePolicy.*/AutomaticUpdatePolicy=stage/' /etc/rpm-ostreed.conf && \
     systemctl enable rpm-ostreed-automatic.timer && \
     systemctl enable flatpak-automatic.timer && \
     ostree container commit
+
+# Vanilla-first-setup
+COPY --from=ghcr.io/adamisrael/vanilla-first-setup:latest /first-setup/vanilla-first-setup.tar.gz /tmp/vanilla-first-setup.tar.gz
+RUN tar xf /tmp/vanilla-first-setup.tar.gz --strip-component=1 -C / && \
+    chmod +x /usr/local/bin/vanilla-first-setup


### PR DESCRIPTION
This PR adds the `vte291-gtk4-devel.x86_64` dependency, which includes a required python library, and installs `vanilla-first-setup` from a build layer in my repo. We may want to move that repo under `ublue-os` similar to the `udev-rules` layer.

This does *not* include the json recipe needed to replace `ublue-firstboot`. It just gives us the required bits to start the recipe to replace it.