### PR TITLE
fix: Add vte dependency for first-setup

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -31,7 +31,7 @@ COPY etc /etc
 COPY ublue-firstboot /usr/bin
 
 RUN rpm-ostree override remove firefox firefox-langpacks && \
-    rpm-ostree install distrobox gnome-tweaks just && \
+    rpm-ostree install distrobox gnome-tweaks just vte291-gtk4-devel && \
     sed -i 's/#AutomaticUpdatePolicy.*/AutomaticUpdatePolicy=stage/' /etc/rpm-ostreed.conf && \
     systemctl enable rpm-ostreed-automatic.timer && \
     systemctl enable flatpak-automatic.timer && \


### PR DESCRIPTION
Adds the `vte291-gtk4-devel` package required for `first-setup` to run.