### PR TITLE
chore: add image metadata

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,7 +56,18 @@ jobs:
             fi
           fi
           echo "alias_tags=${alias_tags[*]}" >> $GITHUB_OUTPUT
-
+        
+      # Build metadata
+      - name: Image Metadata
+        uses: docker/metadata-action@v4
+        id: meta
+        with:
+          images: |
+            ${{ env.IMAGE_NAME }}
+          labels: |
+            io.artifacthub.package.readme-url=https://raw.githubusercontent.com/ublue-os/base/main/README.md
+            io.artifacthub.package.logo-url="https://avatars.githubusercontent.com/u/120078124?s=200&v=4"
+      
       # Build image using Buildah action
       - name: Build Image
         id: build_image
@@ -71,7 +82,8 @@ jobs:
             ${{ steps.generate-tags.outputs.sha_short }}
           build-args: |
             FEDORA_MAJOR_VERSION=${{ matrix.major_version }}
-          oci: true
+          labels: ${{ steps.meta.outputs.labels }}
+          oci: false
 
       # Workaround bug where capital letters in your GitHub username make it impossible to push to GHCR.
       # https://github.com/macbre/push-to-ghcr/issues/12


### PR DESCRIPTION
This will add proper labels to the images, the io.artifacthub labels are so we can show up on artifacthub