### PR TITLE
fix: remove 38 builds and fix logo metadata

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        major_version: [37, 38]
+        major_version: [37]
         include:
           - major_version: 37
             is_latest: true
@@ -66,7 +66,7 @@ jobs:
             ${{ env.IMAGE_NAME }}
           labels: |
             io.artifacthub.package.readme-url=https://raw.githubusercontent.com/ublue-os/base/main/README.md
-            io.artifacthub.package.logo-url="https://avatars.githubusercontent.com/u/120078124?s=200&v=4"
+            io.artifacthub.package.logo-url=https://avatars.githubusercontent.com/u/120078124?s=200&v=4
       
       # Build image using Buildah action
       - name: Build Image


### PR DESCRIPTION
Let's enable 38 after we fix the build