### PR TITLE
feat: split flatpak update units into user and system

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -9,6 +9,7 @@ FROM quay.io/fedora-ostree-desktops/silverblue:${FEDORA_MAJOR_VERSION}
 RUN wget https://copr.fedorainfracloud.org/coprs/ublue-os/vanilla-first-setup/repo/fedora-$(rpm -E %fedora)/ublue-os-vanilla-first-setup-fedora-$(rpm -E %fedora).repo -O /etc/yum.repos.d/_copr_ublue-os-vanilla-first-setup.repo
 
 COPY etc /etc
+COPY usr /usr
 
 COPY ublue-firstboot /usr/bin
 
@@ -16,7 +17,8 @@ RUN rpm-ostree override remove firefox firefox-langpacks && \
     rpm-ostree install distrobox gnome-tweaks just vte291-gtk4-devel vanilla-first-setup && \
     sed -i 's/#AutomaticUpdatePolicy.*/AutomaticUpdatePolicy=stage/' /etc/rpm-ostreed.conf && \
     systemctl enable rpm-ostreed-automatic.timer && \
-    systemctl enable flatpak-automatic.timer && \
+    systemctl enable flatpak-system-update.timer && \
+    systemctl enable flatpak-user-update.timer && \
     sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/_copr_ublue-os-vanilla-first-setup.repo && \
     rm -rf \
         /tmp/* \

--- a/Containerfile
+++ b/Containerfile
@@ -18,7 +18,6 @@ RUN rpm-ostree override remove firefox firefox-langpacks && \
     sed -i 's/#AutomaticUpdatePolicy.*/AutomaticUpdatePolicy=stage/' /etc/rpm-ostreed.conf && \
     systemctl enable rpm-ostreed-automatic.timer && \
     systemctl enable flatpak-system-update.timer && \
-    systemctl enable flatpak-user-update.timer && \
     sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/_copr_ublue-os-vanilla-first-setup.repo && \
     rm -rf \
         /tmp/* \

--- a/ublue-firstboot
+++ b/ublue-firstboot
@@ -125,7 +125,17 @@ if [ "$?" != 0 ] ; then
           --text="Installing Celluloid Failed"
         exit 1
 fi
+echo "95"
+
+echo "Enabling Flatpak auto update"
+/usr/bin/systemctl --user enable --now flatpak-user-update.timer
+if [ "$?" != 0 ] ; then
+        zenity --error \
+          --text="Setting Flatpak Autoupdate Failed"
+        exit 1
+fi
 echo "100"
+
 
 echo "# Reticulating Final Splines"
 mkdir -p "$HOME"/.config/ublue/

--- a/usr/lib/systemd/system/flatpak-system-update.service
+++ b/usr/lib/systemd/system/flatpak-system-update.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Flatpak Automatic Update
+Documentation=man:flatpak(1)
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/flatpak --system update -y --noninteractive
+
+[Install]
+WantedBy=multi-user.target

--- a/usr/lib/systemd/system/flatpak-system-update.timer
+++ b/usr/lib/systemd/system/flatpak-system-update.timer
@@ -1,5 +1,5 @@
 [Unit]
-Description=flatpak Automatic Update Trigger
+Description=Flatpak Automatic Update Trigger
 Documentation=man:flatpak(1)
 
 [Timer]

--- a/usr/lib/systemd/user/flatpak-user-update.service
+++ b/usr/lib/systemd/user/flatpak-user-update.service
@@ -1,12 +1,12 @@
 [Unit]
-Description=flatpak Automatic Update
+Description=Flatpak Automatic Update
 Documentation=man:flatpak(1)
 Wants=network-online.target
 After=network-online.target
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/flatpak update -y
+ExecStart=/usr/bin/flatpak --user update -y --noninteractive
 
 [Install]
 WantedBy=multi-user.target

--- a/usr/lib/systemd/user/flatpak-user-update.timer
+++ b/usr/lib/systemd/user/flatpak-user-update.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Flatpak Automatic Update Trigger
+Documentation=man:flatpak(1)
+
+[Timer]
+OnBootSec=5m
+OnCalendar=0/6:00:00
+Persistent=true
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
This splits the updater service units into two, one for --user installed flatpaks and one for --system installed flatpaks. 

The zenity thing defaults to --user but this should cover the case where users prefer --system. This also fixes #71