### PR TITLE
feat: add script to add installed flatpaks to $PATH

### DIFF
--- a/etc/profile.d/flatpak-bindir.sh
+++ b/etc/profile.d/flatpak-bindir.sh
@@ -1,0 +1,9 @@
+if [ -n "$XDG_DATA_HOME" ] && [ -d "$XDG_DATA_HOME/flatpak/exports/bin" ]; then
+  pathmunge "$XDG_DATA_HOME/flatpak/exports/bin"
+elif [ -n "$HOME" ] && [ -d "$HOME/.local/share/flatpak/exports/bin" ]; then
+  pathmunge "$HOME/.local/share/flatpak/exports/bin"
+fi
+
+if [ -d /var/lib/flatpak/exports/bin ]; then
+  pathmunge /var/lib/flatpak/exports/bin
+fi


### PR DESCRIPTION
Arch Linux ships [a script](https://gitlab.archlinux.org/archlinux/packaging/packages/flatpak/-/blob/main/flatpak-bindir.sh) that adds flatpaks to the PATH variable.

The function `append_path` doesn't exist in Fedora it's called `pathmunge` instead.
They are both located in /etc/profile by default on both distros.

Now if you want to start a flatpak from terminal you can just type
`$ org.mozilla.firefox`
instead of 
`$ flatpak run org.mozilla.firefox`

